### PR TITLE
Ide87 visualizar imágenes en paginas de inmuebles

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,18 @@
 import React from "react";
-import { Routes, Route, Link } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import { useContext } from "react";
 
 import AppLayout from "./components/app/appLayout/AppLayout";
+import Login from "./pages/login/Login";
 import RealEstateSearcher from "./pages/realEstates/realEstateSearcher/RealEstateSearcher";
 import RealEstateDetails from "./pages/realEstates/realEstateDetails/RealEstateDetails";
 import RealEstateForm from "./pages/realEstates/realEstateForm/realEstateForm";
 import RealEstateList from "./pages/realEstates/realEstateList/RealEstateList";
 import RealEstateListMap from "./pages/realEstates/realEstateListMap/RealEstateListMap";
 import Register from "./pages/register/Register";
-import Login from "./pages/login/Login";
 import UserProfile from "./pages/profile/UserProfile/UserProfile";
 import UserContext from "./context/UserContext";
 
-import "slick-carousel/slick/slick.css";
-import "slick-carousel/slick/slick-theme.css";
 import Favorite from "./pages/favoritos/Favorite";
 
 

--- a/frontend/src/components/app/appLayout/AppLayout.jsx
+++ b/frontend/src/components/app/appLayout/AppLayout.jsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router-dom";
 
-import AppNav from "../appnav/AppNav";
+import AppNav from "../appNav/AppNav";
 import AppFooter from "../appFooter/AppFooter";
 
 

--- a/frontend/src/components/googleMaps/marker/GoogleMapsMarker.jsx
+++ b/frontend/src/components/googleMaps/marker/GoogleMapsMarker.jsx
@@ -33,7 +33,7 @@ function GoogleMapsMarker (options) {
           '<label styles="font-size:16px; font-weight:400">'+realestate.metersBuilt+' m2</label>'+
         '</div>'+
         '<div style="margin-top:10px; font-size:16px; font-weight:400; width:300px">'+realestate.shortDescription+'</div>'+
-        '<div style="margin-top:10px; font-size:16px; font-weight:700">'+realestate.state+'</div>'
+        '<div style="margin-top:10px; font-size:16px; font-weight:700">'+realestate.state.replace("-"," ")+'</div>'
       '</div>'
 
     const infowindow = new google.maps.InfoWindow({

--- a/frontend/src/components/googleMaps/marker/GoogleMapsMarker.jsx
+++ b/frontend/src/components/googleMaps/marker/GoogleMapsMarker.jsx
@@ -5,18 +5,21 @@ import imageM2 from "../../../assets/m2.svg"
 import imageRooms from "../../../assets/cama.svg"
 
 
-
 function GoogleMapsMarker (options) {
     const {map, realestate, markerRef} = options;
     const markerOptions = {map: map, position: realestate.publicposition, optimized: false}
     const [marker, setMarker] = useState();
     const realEstateLink = "/realestates/"+realestate._id;
+    
+    const urlDefaultImg = "https://img3.idealista.com/blur/WEB_DETAIL_TOP-L-L/0/id.pro.es.image.master/fd/b9/4c/1044663570.jpg";
+    if (realestate.images.length === 0) realestate.images.push(urlDefaultImg);
+    console.log("marker.images:", realestate.images[0])
 
     const contentString =
       '<div>'+
         '<div>'+
           '<a style="text-decoration:none" href='+realEstateLink+' target="_blank">'+
-            '<img style="height:170px; width=170px" src="https://img3.idealista.com/blur/WEB_DETAIL_TOP-L-L/0/id.pro.es.image.master/fd/b9/4c/1044663570.jpg" alt="Imagen inmueble"/>'+
+            '<img style="height:170px; width=170px; margin:auto;" src='+realestate.images[0]+' alt="Imagen inmueble"/>'+
             '<div style="margin-top:10px; font-size:16px; font-weight:400">'+realestate.roadName+", "+realestate.roadNumber+" ("+realestate.location+')'+'</div>'+
           '</a>'+
         '</div>'+

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 
-
 import realEstateApi from "../../../utils/apis/realEstateApi";
 import Carousel from "./RealEstateDetailsCarousel";
 import GoogleMapsReactWrapper from "../../../components/googleMaps/reactWrapper/GoogleMapsReactWrapper";

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
@@ -4,9 +4,7 @@ import { useParams } from "react-router-dom";
 
 
 import realEstateApi from "../../../utils/apis/realEstateApi";
-import TextArea from "./TextArea";
 import Carousel from "./RealEstateDetailsCarousel";
-
 import GoogleMapsReactWrapper from "../../../components/googleMaps/reactWrapper/GoogleMapsReactWrapper";
 import GoogleMapsIndividual from "../../../components/googleMaps/map/GoogleMapsIndividual";
 
@@ -28,41 +26,47 @@ const RealEstateDetails = () => {
     if (!data) return <div> Something went wrong</div>;
 
     return (
-        <div>
+        <div style={{width:"1140px", margin:"auto"}}>
             <div className={styles.carousel_container}>
-                <Carousel height={500} width={1082} />
+                <Carousel height={"500px"} width={"1140px"} images={data.images} />
+            </div>
+
+            <div className={styles.buttons}>
+                <div style={{display:"flex", flexDirection:"row", alignItems:"center"}}>
+                    <img style={{ height: "16px", width: "16px" }} src={likeImag} />
+                    <span style={{marginLeft:"5px"}}>Me gusta</span>
+                </div>
+                <div style={{display:"flex", flexDirection:"row", alignItems:"center"}}>
+                    <img style={{ height: "16px", width: "16px" }} src={compartir} />
+                    <span style={{marginLeft:"5px"}}>Compartir</span>
+                </div>                
+                <h4 style={{ color: "#6D96FF" }} >
+                    {data?.price} €
+                </h4>
+                <button className={styles.contact_button} onClick={() => {
+                            contactar(input);
+                            setInput("");}}>Contactar con anunciante
+                </button>
+            </div>
+
+            <div className={styles.container_text}>
+                <h3> {data?.shortDescription} </h3>
+                <h3> {data?.location}</h3>
+                <textarea style={{fontSize:"16px", border:"none", outline:"none",
+                                    minHeight:"550px", 
+                                    minWidth:"1140px", maxWidth:"1140px"}}
+                        readOnly
+                        value={data?.description}/>
             </div>
 
             <div className={styles.columnContainer}>
                 <div className={styles.leftColumn}>
-                    <div className={styles.buttons}>
-                        <div>
-                            <img style={{ height: "16px", width: "16px" }} src={likeImag} /> Me gusta
-                        </div>
-                        <div>
-                            <img style={{ height: "16px", width: "16px" }} src={compartir} /> Compartir
-                        </div>
-                        <h4 style={{ color: "#6D96FF" }} >
-                            {data?.price} €
-                        </h4>
-                    </div>
-
-                    <div className={styles.container_text}>
-                        <h2> {data?.shortDescription} </h2>
-                        <h3> {data?.location}</h3>
-                        <textarea style={{fontSize:"16px", border:"none", outline:"none",
-                                          minHeight:"300px", 
-                                          minWidth:"650px", maxWidth:"650px"}}
-                                readOnly
-                                value={data?.description}/>
-                    </div>
-
                     <div className={styles.caracteristicas}>
                         <h2>Características básicas</h2>
                         <div>
                             <p>{data?.realEstateType + ": " + data?.realEstateSubtype}</p>
                             <p>{data?.properties.map((element) => {
-                                return <span>{element+" "}</span>
+                                return <span key={element}>{element+" "}</span>
                             })}</p>
                             <p>{data?.metersBuilt + " m2"}</p>
                             <p>{data?.state}</p>
@@ -73,7 +77,6 @@ const RealEstateDetails = () => {
                 </div>
 
                 <div className={styles.rightColumn}>
-                    <TextArea contactar={sendMessageToAdvisor}> </TextArea>
                     <GoogleMapsReactWrapper>
                         <GoogleMapsIndividual
                             center={{

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 
@@ -16,6 +16,10 @@ import likeImag from "../../../assets/me-gusta.png"
 const RealEstateDetails = () => {
     const { id } = useParams();
     const { data, isLoading } = useQuery('realEstateDetail', () => realEstateApi.GetRealEstate(id));
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [])
 
     const sendMessageToAdvisor = (messageContent) => {
         alert("Mensaje enviado")

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.module.css
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetails.module.css
@@ -1,52 +1,17 @@
-.container_text {
-    display: flex;
-    flex-direction: column;
+.carousel_container {
+    width: 1140px;
+    height: 510px;
+    margin: auto;
+    margin-top: 30px;
+}
+
+.buttons {
     width: 100%;
-}
-
-.justify_center {
-    justify-content: center;
-}
-
-.gap {
-    gap: 88px;
-}
-
-.flex {
     display: flex;
-    flex-direction: row;
-}
-
-.flex_column {
-    flex-direction: column;
-}
-
-.map_image {
-    width: 80%;
-    height: 80%;
-    flex-shrink: 2;
-    border-radius: 29px;
-    background: #CFE2FF;
-    margin: 10px;
-    margin-left: 20px;
-}
-
-.columnContainer {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    align-items: start;
-    justify-content: center;
-}
-
-.input_area {
-    display: flex;
-    width: 380px;
-    height: 227px;
-    border-radius: 19px;
-    background: #FFF;
-    margin: 20px;
-    padding: 10px;
+    justify-content: space-evenly; 
+    align-items: center;
+    align-items: center;
+    margin-top: 45px;
 }
 
 .contact_button {
@@ -66,19 +31,24 @@
     cursor: pointer;
 }
 
-.carousel_container {
-    width: 1082px;
-    height: 500px;
-    margin: auto;
-    margin-top: 30px;
+.container_text {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.columnContainer {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    align-items: start;
+    margin-top: 45px;
 }
 
 .leftColumn {
     width: 100%;
-    max-width: 50%;
     display: flex;
     flex-direction: column;
-    margin-top: 50px;
 }
 
 .rightColumn {
@@ -86,21 +56,14 @@
     max-width: 400px;
     display: flex;
     flex-direction: column;
-    margin-top: 50px;
     align-items: center;
 }
 
-.buttons {
-    width: 100%;
+.caracteristicas {
     display: flex;
-    justify-content: space-evenly;
-    align-items: center;
+    flex-direction: column;
 }
 
-.details_container {
-    margin: auto;
-    width: 1140px;
-}
 
 h4 {
     margin: 0;
@@ -108,11 +71,6 @@ h4 {
     font-style: normal;
     font-weight: 700;
     line-height: normal;
-}
-
-.caracteristicas {
-    display: flex;
-    flex-direction: column;
 }
 
 p {
@@ -123,6 +81,8 @@ p {
     line-height: normal;
 }
 
+
+
 h2, h3 {
     line-height: 1.1;
 }
@@ -130,3 +90,27 @@ h2, h3 {
 h2 {
     margin-top: 50px;
 }
+
+
+
+.justify_center {
+    justify-content: center;
+}
+
+.gap {
+    gap: 88px;
+}
+
+.flex {
+    display: flex;
+    flex-direction: row;
+}
+
+.flex_column {
+    flex-direction: column;
+}
+
+
+
+
+

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
@@ -1,26 +1,40 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Slider from "react-slick";
 
 import styles from "./RealEstateDetailsCarousel.module.css";
 import house_image from "../../../assets/pexels-aaron-cook-19277901 1.png"
 
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
 
-const Carousel = () => {
-    const images = [house_image, house_image, house_image]
+
+const Carousel = (props) => {
+    const {height, width, images} = props || []
+    if (images.length === 0) images.push = house_image;
+
+/*    useEffect(() => {
+    }, [images])
+*/
+
     const settings = {
         useCSS: true,
         dots: true,
-        speed: 400,
+        speed: 500,
         slidesToShow: 1,
         slidesToScroll: 1,
         infinite: true,
         autoplay: true,
-        autoplaySpeed: 4000,
+        autoplaySpeed: 5000
     };
 
     return (
         <Slider {...settings}>
-            {images.map((i, index) => <img key={`image_carousel_${index}`} className={styles.rounded} src={i} />)}
+            {images.map((i, index) =>   <div style={{height:props.height, width:props.width}} key={"div"+i}>
+                                            <img key={`image_carousel_${index}`} 
+                                                 className={styles.rounded} 
+                                                 src={i}
+                                                 style={{height:props.height, width:"auto", margin:"auto"}} />
+                                        </div>)}
         </Slider>
     )
 };

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Slider from "react-slick";
 
 import styles from "./RealEstateDetailsCarousel.module.css";
@@ -11,10 +11,6 @@ import "slick-carousel/slick/slick-theme.css";
 const Carousel = (props) => {
     const {height, width, images} = props || []
     if (images.length === 0) images.push = house_image;
-
-/*    useEffect(() => {
-    }, [images])
-*/
 
     const settings = {
         useCSS: true,
@@ -29,11 +25,11 @@ const Carousel = (props) => {
 
     return (
         <Slider {...settings}>
-            {images.map((i, index) =>   <div style={{height:props.height, width:props.width}} key={"div"+i}>
+            {images.map((i, index) =>   <div style={{height:height, width:width}} key={"div"+i}>
                                             <img key={`image_carousel_${index}`} 
                                                  className={styles.rounded} 
                                                  src={i}
-                                                 style={{height:props.height, width:"auto", margin:"auto"}} />
+                                                 style={{height:height, width:"auto", margin:"auto"}} />
                                         </div>)}
         </Slider>
     )

--- a/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
+++ b/frontend/src/pages/realEstates/realEstateDetails/RealEstateDetailsCarousel.jsx
@@ -10,7 +10,7 @@ import "slick-carousel/slick/slick-theme.css";
 
 const Carousel = (props) => {
     const {height, width, images} = props || []
-    if (images.length === 0) images.push = house_image;
+    if (images.length === 0) images.push(house_image);
 
     const settings = {
         useCSS: true,

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateList.jsx
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateList.jsx
@@ -1,22 +1,21 @@
 import { useContext, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import realEstateApi from "../../../utils/apis/realEstateApi";
 import favoriteApi from "../../../utils/apis/favoriteApi";
 import RealEstateListElement from "./RealEstateListElement";
 import RealEstateNumber from "../../../components/realestates/RealEstateNumber";
 import RealEstateOperation from "../../../components/realestates/RealEstateOperations";
-import RealEstatePrice from "../../../components/realestates/RealEstatePrices";
+import RealEstatePrices from "../../../components/realestates/RealEstatePrices";
 import RealEstateStates from "../../../components/realestates/RealEstateStates";
 import RealEstateType from "../../../components/realestates/RealEstateType";
-
 
 import styles from "./RealEstateList.module.css";
 import imageList from "../../../assets/lista.svg";
 import imageMap from "../../../assets/marcador.svg";
-import RealEstatePrices from "../../../components/realestates/RealEstatePrices";
 import UserContext from "../../../context/UserContext";
+
 
 
 function RealEstateList() {

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateList.jsx
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateList.jsx
@@ -95,7 +95,7 @@ function RealEstateList() {
 
             <div style={{ display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
                 <div>
-                    <h2>{operation + " > " + realEstateType + " > " + localization + " (" + query.data.length + ")"}</h2>
+                    <h3>{operation + " > " + realEstateType + " > " + localization + " (" + query.data.length + ")"}</h3>
                 </div>
                 <div>
                     <ul>

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
@@ -36,8 +36,8 @@
     font-weight: 700;
     text-align: center;
     margin: 1px;
-    padding-top: 10px; 
-    height: 35px;
+    padding-top: 15px; 
+    height: 30px;
     width: 130px;
 }
 
@@ -49,9 +49,9 @@
     font-size: 16px;
     font-weight: 700;
     text-align: center;
-    padding-top: 10px; 
     margin: 1px;
-    height: 35px;
+    padding-top: 15px; 
+    height: 30px;
     width: 130px;
 }
 

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
@@ -14,6 +14,7 @@
     margin: 10px;
     display: flex;
     flex-direction: row;
+    width: 942px;
 }
 
 .image {

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateList.module.css
@@ -14,7 +14,6 @@
     margin: 10px;
     display: flex;
     flex-direction: row;
-    width: fit-content;
 }
 
 .image {

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
@@ -19,13 +19,13 @@ function RealEstateListElement({ realEstate, onFavorite }) {
 
     return (
         <div className={styles.card}>
-            <div>
+            <div style={{width:"260px"}}>
                 <Link to={`/realestates/${realEstate._id}`}>
                     <img className={styles.image} src={realEstate.images[0]} alt="Imagen inmueble" />
                     
                 </Link>
             </div>
-            <div>
+            <div style={{width:"645px"}}>
                 <div style={{ marginTop: "5px" }}>
                     <Link className={styles.link} to={`/realestates/${realEstate._id}`}>
                         <span style={{ fontSize: "20px", fontWeight: "700", textDecoration: "none" }}>{realEstate.roadName + ", " + realEstate.roadNumber + " (" + realEstate.location + ')'}</span>
@@ -43,7 +43,7 @@ function RealEstateListElement({ realEstate, onFavorite }) {
                 <div>{realEstate.shortDescription}</div>
                 <div style={{ marginTop: "5px", fontWeight: "700" }}>{realEstate.state.replace("-"," ")}</div>
             </div>
-            <div>
+            <div style={{width:"35"}}>
                 <UseAnimation animation={heart} reverse={realEstate.fav} fillColor="#CFE2FF" size={35} onClick={() => onFavorite && onFavorite(realEstate)} />
             </div>
         </div>

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
@@ -36,7 +36,7 @@ function RealEstateListElement({ realEstate, onFavorite }) {
                     <div style={{ marginLeft: "10px" }}>{realEstate.metersBuilt} m2</div>
                 </div>
                 <div>{realEstate.shortDescription}</div>
-                <div style={{ marginTop: "5px", fontWeight: "700" }}>{realEstate.state}</div>
+                <div style={{ marginTop: "5px", fontWeight: "700" }}>{realEstate.state.replace("-"," ")}</div>
             </div>
             <div>
                 <UseAnimation animation={heart} reverse={realEstate.fav} fillColor="#CFE2FF" size={35} onClick={() => onFavorite && onFavorite(realEstate)} />

--- a/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
+++ b/frontend/src/pages/realEstates/realEstateList/RealEstateListElement.jsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import UseAnimation from "react-useanimations";
 import heart from "react-useanimations/lib/heart";
 
+import Carrusel from "../realEstateDetails/RealEstateDetailsCarousel"
+
 import styles from "./RealEstateList.module.css"
 import house_image from "../../../assets/pexels-aaron-cook-19277901 1.png"
 import imageBathrooms from "../../../assets/bano.svg"
@@ -13,11 +15,14 @@ import imageRooms from "../../../assets/cama.svg"
 
 function RealEstateListElement({ realEstate, onFavorite }) {
 
+    if (realEstate.images.length === 0) realEstate.images.push(house_image);
+
     return (
         <div className={styles.card}>
             <div>
                 <Link to={`/realestates/${realEstate._id}`}>
-                    <img className={styles.image} src={house_image} alt="Imagen inmueble" />
+                    <img className={styles.image} src={realEstate.images[0]} alt="Imagen inmueble" />
+                    
                 </Link>
             </div>
             <div>

--- a/frontend/src/pages/realEstates/realEstateListMap/RealEstateListMap.jsx
+++ b/frontend/src/pages/realEstates/realEstateListMap/RealEstateListMap.jsx
@@ -36,7 +36,7 @@ function RealEstateListMap(){
       <div style={{ margin: "auto", width: "1140px", height: "100vh"}}>
           <div style={{ display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
               <div>
-                  <h2>{operation + " > " + realEstateType + " > " + localization}</h2>
+                  <h3>{operation + " > " + realEstateType + " > " + localization}</h3>
               </div>
               <div>
                   <ul>

--- a/frontend/src/pages/realEstates/realEstateListMap/RealEstateListMap.module.css
+++ b/frontend/src/pages/realEstates/realEstateListMap/RealEstateListMap.module.css
@@ -8,8 +8,8 @@
     font-weight: 700;
     text-align: center;
     margin: 1px;
-    padding-top: 10px;
-    height: 35px;
+    padding-top: 15px; 
+    height: 30px;
     width: 130px;
 }
 
@@ -21,9 +21,9 @@
     font-size: 16px;
     font-weight: 700;
     text-align: center;
-    padding-top: 10px;
     margin: 1px;
-    height: 35px;
+    padding-top: 15px; 
+    height: 30px;
     width: 130px;
 }
 


### PR DESCRIPTION
Visualiza las imágenes reales del inmueble en las diferentes páginas de la aplicación:
- Lista de inmuebles, visualiza la imagen del inmueble (1a imagen), si no tiene imagen muestra una imagen predeterminada
- Detalle de inmuebles, visualiza en el carrusel las imágenes del inmueble, si no tiene imagen muestra una imagen predeterminada
- Mapa, ventana de información del inmueble, , visualiza la imagen del inmueble (1a imagen), si no tiene imagen muestra una imagen predeterminada

Se ha actualizado los estilos y diseño:
- Lista de inmuebles actualizado estilos
- Detalle de inmueble actualizado diseño (se ha quitado el textarea de contacto y se ha reubicado los campos)
- Mapa de inmuebles actualizado estilos

<img width="580" alt="image" src="https://github.com/nds-fsd/idealista/assets/146576217/fe28228b-2c5e-4da6-9cfd-59fb25f7974e">
<img width="339" alt="image" src="https://github.com/nds-fsd/idealista/assets/146576217/495e3050-ef4a-40bb-9c70-33140f9991fb">
<img width="643" alt="image" src="https://github.com/nds-fsd/idealista/assets/146576217/7af6129f-d4e2-4502-9807-998a7d1a2391">
